### PR TITLE
Unicode text support

### DIFF
--- a/lib/markdoc/pseudocode.treetop
+++ b/lib/markdoc/pseudocode.treetop
@@ -25,7 +25,7 @@ module Markdoc
     end
 
     rule word
-      [a-zA-Z0-9 ]+
+      [^\n]+
     end
 
     rule space

--- a/test/test_pseudocode.rb
+++ b/test/test_pseudocode.rb
@@ -7,8 +7,8 @@ class PseudocodeTest < Minitest::Test
   def test_conditional
     code = <<-CODE
 if you thursty
-  go to fridge
-  if there is coce
+  go to fridge (хөргөгч рүү очих)
+  if there is coke
     drink it
   else
     buy one
@@ -26,8 +26,8 @@ CODE
     graphviz = <<-GRAPH
 digraph G {
 N1 [shape=diamond label="you thursty"]
-N2 [shape=box label="go to fridge"]
-N3 [shape=diamond label="there is coce"]
+N2 [shape=box label="go to fridge (хөргөгч рүү очих)"]
+N3 [shape=diamond label="there is coke"]
 N4 [shape=box label="drink it"]
   N3 -> N4 [label="Yes"]
 N5 [shape=box label="buy one"]


### PR DESCRIPTION
Currently Markdoc fails if pseoudocode contain unicode string (technically `sentence`).
This pull request enabling unicode sentence in pseoudocode.
