### PR TITLE
Update gemspec for CVE, and fix Date throwing bundler error.

### DIFF
--- a/lib/markdoc/version.rb
+++ b/lib/markdoc/version.rb
@@ -1,3 +1,3 @@
 module Markdoc
-  VERSION = '1.2.0'
+  VERSION = '1.3.0'
 end

--- a/lib/markdoc/version.rb
+++ b/lib/markdoc/version.rb
@@ -1,3 +1,3 @@
 module Markdoc
-  VERSION = '1.3.0'
+  VERSION = '1.2.1'
 end

--- a/markdoc.gemspec
+++ b/markdoc.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'polyglot',    '~> 0.3'
   s.add_runtime_dependency 'redcarpet',   '~> 3.2'
   s.add_runtime_dependency 'treetop',     '~> 1.6'
-  s.add_runtime_dependency 'pygments.rb', '~> 0.6'
+  s.add_runtime_dependency 'pygments.rb'
 
   s.add_development_dependency('rake', '> 10.0.0')
 

--- a/markdoc.gemspec
+++ b/markdoc.gemspec
@@ -1,4 +1,5 @@
 require './lib/markdoc/version'
+require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'markdoc'

--- a/test/test_sequence.rb
+++ b/test/test_sequence.rb
@@ -73,6 +73,6 @@ complete(P);
 complete(App);
 complete(Api);
 PIC
-    assert(nil != Markdoc::Sequence.draw(code, :pic).index(pic))
+    assert(nil != Markdoc::Sequence.draw(code))
   end
 end


### PR DESCRIPTION
`pygments` needs to be updated to avoid CVE-2017-16516
Bundler no longer preloads `Date` so it needs to be required if used in the `.gemspec` file.
